### PR TITLE
Twitter Pink Screen Fix

### DIFF
--- a/BluBotCore/Handlers/LogHandler.cs
+++ b/BluBotCore/Handlers/LogHandler.cs
@@ -47,7 +47,7 @@ namespace BluBotCore.Handlers
             if (msg.Severity == LogSeverity.Error || msg.Severity == LogSeverity.Warning || msg.Severity == LogSeverity.Critical)
             {
                 string msge = msg.ToString();
-                if (msg.Message.Contains("System.Exception: Unexpected close")) msge = msg.Message;
+                if (msg.Message != null && msg.Message.Contains("System.Exception: Unexpected close")) msge = msg.Message;
                 var mahsaap = _client.GetUser(88798728948809728) as IUser;
                 mahsaap.SendMessageAsync(msge);
             }

--- a/BluBotCore/Services/LiveMonitor.cs
+++ b/BluBotCore/Services/LiveMonitor.cs
@@ -35,7 +35,7 @@ namespace BluBotCore.Services
             private static readonly int TWITCH_PINK_SCREEN_RETRY_DELAY = 15000; //ms
 
             #region Lists
-        private static List<string> _chansName = new List<string>();
+                private static List<string> _chansName = new List<string>();
                 private static List<string> _chansID = new List<string>();
             #endregion
 

--- a/BluBotCore/Services/LiveMonitor.cs
+++ b/BluBotCore/Services/LiveMonitor.cs
@@ -370,7 +370,7 @@ namespace BluBotCore.Services
             {
                 WebClient webClient = new WebClient();
                 byte[] image = webClient.DownloadData(url);
-                //attempt to get an image 10 times
+
                 for (int i = 0; i < TWITCH_PINK_SCREEN_RETRY_ATTEMPTS; i++)
                 {
                     byte[] hash;

--- a/BluBotCore/Services/LiveMonitor.cs
+++ b/BluBotCore/Services/LiveMonitor.cs
@@ -369,11 +369,10 @@ namespace BluBotCore.Services
             try
             {
                 WebClient webClient = new WebClient();
-                byte[] image = null;
+                byte[] image = webClient.DownloadData(url);
                 //attempt to get an image 10 times
                 for (int i = 0; i < TWITCH_PINK_SCREEN_RETRY_ATTEMPTS; i++)
                 {
-                    image = webClient.DownloadData(url);
                     byte[] hash;
                     using (var sha256 = System.Security.Cryptography.SHA256.Create())
                     {
@@ -384,6 +383,7 @@ namespace BluBotCore.Services
                         //pink screen detected. Lets sleep for X seconds and try again. 
                         Console.WriteLine($"{DateTime.Now.ToString("HH:MM:ss")} Twitter     Detected Pink Screen for {url}, trying again in {TWITCH_PINK_SCREEN_RETRY_DELAY}, attempt {i+1} out of {TWITCH_PINK_SCREEN_RETRY_ATTEMPTS}" );
                         await Task.Delay(TWITCH_PINK_SCREEN_RETRY_DELAY);
+                        image = webClient.DownloadData(url);
                     } else
                     {
                         //not a pink screen. Break out of loop

--- a/BluBotCore/Services/LiveMonitor.cs
+++ b/BluBotCore/Services/LiveMonitor.cs
@@ -30,10 +30,12 @@ namespace BluBotCore.Services
             private readonly IServiceProvider _service;
 
             private static DateTime _onlineTime;
-            private static string _twitterURL = "";
+            private static readonly byte[] TWITCH_PINK_SCREEN_CHECKSUM = new byte[] { 11, 241, 144, 174, 218, 192, 175, 31, 120, 108, 52, 36, 55, 174, 200, 134, 12, 8, 223, 245, 175, 184, 76, 16, 140, 201, 39, 57, 123, 39, 23, 78 };
+            private static readonly int TWITCH_PINK_SCREEN_RETRY_ATTEMPTS = 3;
+            private static readonly int TWITCH_PINK_SCREEN_RETRY_DELAY = 15000; //ms
 
             #region Lists
-                private static List<string> _chansName = new List<string>();
+        private static List<string> _chansName = new List<string>();
                 private static List<string> _chansID = new List<string>();
             #endregion
 
@@ -146,11 +148,9 @@ namespace BluBotCore.Services
 
             string twitterTag = FindTwitterTag(e.Stream.Channel.DisplayName);
 
-            //await TweetMessageAsync($"{e.Stream.Channel.DisplayName} is live playing {e.Stream.Game}! {e.Stream.Channel.Url} {twitterTag}#WYKTV", e.Stream.Preview.Medium + Guid.NewGuid().ToString(), e.Stream.Channel.Name.ToLower());
+            string twitterURL = await TweetMessageAsync($"{e.Stream.Channel.DisplayName} is live playing {e.Stream.Game}! {e.Stream.Channel.Url} {twitterTag}#WYKTV", e.Stream.Preview.Medium + Guid.NewGuid().ToString(), e.Stream.Channel.Name.ToLower());
 
-            await SetupEmbedMessageAsync(eb, e, null, _twitterURL);
-
-            _twitterURL = "";
+            await SetupEmbedMessageAsync(eb, e, null, twitterURL);
         }
 
         private async void _monitor_OnStreamUpdate(object sender, OnStreamUpdateArgs e)
@@ -217,7 +217,6 @@ namespace BluBotCore.Services
         private async void _monitor_OnStreamMonitorStarted(object sender, OnStreamMonitorStartedArgs e)
         {
             _onlineTime = DateTime.Now;
-            _twitterURL = "";
             string time = DateTime.Now.ToString("HH:MM:ss");
             Console.WriteLine($"{time} Monitor     Started");
             _liveEmbeds.Clear();
@@ -365,22 +364,45 @@ namespace BluBotCore.Services
         }
 
 
-        private async Task TweetMessageAsync(string text, string url, string channel)
+        private async Task<String> TweetMessageAsync(string text, string url, string channel)
         {
             try
             {
                 WebClient webClient = new WebClient();
-                byte[] image = webClient.DownloadData(url);
+                byte[] image = null;
+                //attempt to get an image 10 times
+                for (int i = 0; i < TWITCH_PINK_SCREEN_RETRY_ATTEMPTS; i++)
+                {
+                    image = webClient.DownloadData(url);
+                    byte[] hash;
+                    using (var sha256 = System.Security.Cryptography.SHA256.Create())
+                    {
+                        hash = sha256.ComputeHash(image);
+                    }
+                    if (hash.SequenceEqual(TWITCH_PINK_SCREEN_CHECKSUM))
+                    {
+                        //pink screen detected. Lets sleep for X seconds and try again. 
+                        Console.WriteLine($"{DateTime.Now.ToString("HH:MM:ss")} Twitter     Detected Pink Screen for {url}, trying again in {TWITCH_PINK_SCREEN_RETRY_DELAY}, attempt {i+1} out of {TWITCH_PINK_SCREEN_RETRY_ATTEMPTS}" );
+                        await Task.Delay(TWITCH_PINK_SCREEN_RETRY_DELAY);
+                    } else
+                    {
+                        //not a pink screen. Break out of loop
+                        break;
+                    }
+                }
+
                 var publishOptions = new PublishTweetOptionalParameters();
                 publishOptions.MediaBinaries.Add(image);
                 var twitterObject = await TweetAsync.PublishTweet(text, publishOptions);
-                _twitterURL = twitterObject.Url;
+                return twitterObject.Url;
 
             }
             catch (Exception ex)
             {
                 var mahsaap = _client.GetUser(Constants.Discord.Mahsaap) as IUser;
                 await mahsaap.SendMessageAsync(ex.Message + "\n" + ex.StackTrace);
+                //cannot return null - code checks for length > 1
+                return "";
             }
         }
 


### PR DESCRIPTION
Modified the task for posting the Twitter comment by making it return a type String, allowing the removal of the private var _twitterUrl (which is unsafe in async Tasks). 

The image download will check to see if it downloads the SHA256 checksum of the twitch not found logo, and if matched times out for 15x3 attempts (45 seconds). Each pause is logged to console. 

It is possible this affects the bot 30 second timeout @here suppression, although the issue has been observed only in new stream starts and not ongoing streams. 

Note debug/testing code still exists (SetCastersAsync specifically). 